### PR TITLE
Allow users to specify enabled ciphers for start_tls()

### DIFF
--- a/ext/cmain.cpp
+++ b/ext/cmain.cpp
@@ -443,12 +443,12 @@ extern "C" void evma_start_tls (const unsigned long binding)
 evma_set_tls_parms
 ******************/
 
-extern "C" void evma_set_tls_parms (const unsigned long binding, const char *privatekey_filename, const char *certchain_filename, int verify_peer, int use_tls)
+extern "C" void evma_set_tls_parms (const unsigned long binding, const char *privatekey_filename, const char *certchain_filename, int verify_peer, int use_tls, const char *cipherlist)
 {
 	ensure_eventmachine("evma_set_tls_parms");
 	EventableDescriptor *ed = dynamic_cast <EventableDescriptor*> (Bindable_t::GetObject (binding));
 	if (ed)
-		ed->SetTlsParms (privatekey_filename, certchain_filename, (verify_peer == 1 ? true : false), (use_tls == 1 ? true : false));
+               ed->SetTlsParms (privatekey_filename, certchain_filename, (verify_peer == 1 ? true : false), (use_tls == 1 ? true : false), cipherlist);
 }
 
 /******************

--- a/ext/ed.cpp
+++ b/ext/ed.cpp
@@ -1142,7 +1142,7 @@ void ConnectionDescriptor::StartTls()
 	if (SslBox)
 		throw std::runtime_error ("SSL/TLS already running on connection");
 
-	SslBox = new SslBox_t (bIsServer, PrivateKeyFilename, CertChainFilename, bSslVerifyPeer, bSslUseTls, GetBinding());
+	SslBox = new SslBox_t (bIsServer, PrivateKeyFilename, CertChainFilename, bSslVerifyPeer, bSslUseTls, CipherList, GetBinding());
 	_DispatchCiphertext();
 	#endif
 
@@ -1156,7 +1156,7 @@ void ConnectionDescriptor::StartTls()
 ConnectionDescriptor::SetTlsParms
 *********************************/
 
-void ConnectionDescriptor::SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer, bool use_tls)
+void ConnectionDescriptor::SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer, bool use_tls, const char *cipherlist)
 {
 	#ifdef WITH_SSL
 	if (SslBox)
@@ -1167,6 +1167,8 @@ void ConnectionDescriptor::SetTlsParms (const char *privkey_filename, const char
 		CertChainFilename = certchain_filename;
 	bSslVerifyPeer = verify_peer;
        bSslUseTls = use_tls;
+       if (cipherlist && *cipherlist)
+               CipherList = cipherlist;
 	#endif
 
 	#ifdef WITHOUT_SSL

--- a/ext/ed.h
+++ b/ext/ed.h
@@ -69,7 +69,7 @@ class EventableDescriptor: public Bindable_t
 		virtual bool GetSubprocessPid (pid_t*) {return false;}
 
 		virtual void StartTls() {}
-		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer, bool use_tls) {}
+		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer, bool use_tls, const char *cipherlist) {}
 
 		#ifdef WITH_SSL
 		virtual X509 *GetPeerCert() {return NULL;}
@@ -193,7 +193,7 @@ class ConnectionDescriptor: public EventableDescriptor
 		virtual int GetOutboundDataSize() {return OutboundDataSize;}
 
 		virtual void StartTls();
-		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer, bool use_tls);
+		virtual void SetTlsParms (const char *privkey_filename, const char *certchain_filename, bool verify_peer, bool use_tls, const char *cipherlist);
 
 		#ifdef WITH_SSL
 		virtual X509 *GetPeerCert();
@@ -240,6 +240,7 @@ class ConnectionDescriptor: public EventableDescriptor
 		bool bHandshakeSignaled;
 		bool bSslVerifyPeer;
                bool bSslUseTls;
+               std::string CipherList;
 		bool bSslPeerAccepted;
 		#endif
 

--- a/ext/eventmachine.h
+++ b/ext/eventmachine.h
@@ -67,7 +67,7 @@ extern "C" {
 	const unsigned long evma_attach_sd (int sd);
 	const unsigned long evma_open_datagram_socket (const char *server, int port);
 	const unsigned long evma_open_keyboard();
-	void evma_set_tls_parms (const unsigned long binding, const char *privatekey_filename, const char *certchain_filenane, int verify_peer, int use_tls);
+       void evma_set_tls_parms (const unsigned long binding, const char *privatekey_filename, const char *certchain_filenane, int verify_peer, int use_tls, const char *cipherlist);
 	void evma_start_tls (const unsigned long binding);
 
 	#ifdef WITH_SSL

--- a/ext/rubymain.cpp
+++ b/ext/rubymain.cpp
@@ -311,14 +311,14 @@ static VALUE t_start_tls (VALUE self, VALUE signature)
 t_set_tls_parms
 ***************/
 
-static VALUE t_set_tls_parms (VALUE self, VALUE signature, VALUE privkeyfile, VALUE certchainfile, VALUE verify_peer, VALUE use_tls)
+static VALUE t_set_tls_parms (VALUE self, VALUE signature, VALUE privkeyfile, VALUE certchainfile, VALUE verify_peer, VALUE use_tls, VALUE cipherlist)
 {
 	/* set_tls_parms takes a series of positional arguments for specifying such things
 	 * as private keys and certificate chains.
 	 * It's expected that the parameter list will grow as we add more supported features.
 	 * ALL of these parameters are optional, and can be specified as empty or NULL strings.
 	 */
-	evma_set_tls_parms (NUM2ULONG (signature), StringValuePtr (privkeyfile), StringValuePtr (certchainfile), (verify_peer == Qtrue ? 1 : 0), (use_tls == Qtrue ? 1 : 0));
+       evma_set_tls_parms (NUM2ULONG (signature), StringValuePtr (privkeyfile), StringValuePtr (certchainfile), (verify_peer == Qtrue ? 1 : 0), (use_tls == Qtrue ? 1 : 0), StringValuePtr(cipherlist));
 	return Qnil;
 }
 
@@ -1224,7 +1224,7 @@ extern "C" void Init_rubyeventmachine()
 	rb_define_module_function (EmModule, "stop_tcp_server", (VALUE(*)(...))t_stop_server, 1);
 	rb_define_module_function (EmModule, "start_unix_server", (VALUE(*)(...))t_start_unix_server, 1);
 	rb_define_module_function (EmModule, "attach_sd", (VALUE(*)(...))t_attach_sd, 1);
-	rb_define_module_function (EmModule, "set_tls_parms", (VALUE(*)(...))t_set_tls_parms, 5);
+	rb_define_module_function (EmModule, "set_tls_parms", (VALUE(*)(...))t_set_tls_parms, 6);
 	rb_define_module_function (EmModule, "start_tls", (VALUE(*)(...))t_start_tls, 1);
 	rb_define_module_function (EmModule, "get_peer_cert", (VALUE(*)(...))t_get_peer_cert, 1);
 	rb_define_module_function (EmModule, "send_data", (VALUE(*)(...))t_send_data, 3);

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -120,7 +120,7 @@ static void InitializeDefaultCredentials()
 SslContext_t::SslContext_t
 **************************/
 
-SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool use_tls):
+SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool use_tls, const string &cipherlist):
 	pCtx (NULL),
 	PrivateKey (NULL),
 	Certificate (NULL)
@@ -177,7 +177,10 @@ SslContext_t::SslContext_t (bool is_server, const string &privkeyfile, const str
 		assert (e > 0);
 	}
 
-	SSL_CTX_set_cipher_list (pCtx, "ALL:!ADH:!LOW:!EXP:!DES-CBC3-SHA:@STRENGTH");
+       if (cipherlist.length() > 0)
+               SSL_CTX_set_cipher_list (pCtx, cipherlist.c_str());
+       else
+               SSL_CTX_set_cipher_list (pCtx, "ALL:!ADH:!LOW:!EXP:!DES-CBC3-SHA:@STRENGTH");
 
 	if (is_server) {
 		SSL_CTX_sess_set_cache_size (pCtx, 128);
@@ -220,7 +223,7 @@ SslContext_t::~SslContext_t()
 SslBox_t::SslBox_t
 ******************/
 
-SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool use_tls, const unsigned long binding):
+SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool use_tls, const string &cipherlist, const unsigned long binding):
 	bIsServer (is_server),
 	bHandshakeCompleted (false),
 	bVerifyPeer (verify_peer),
@@ -233,7 +236,7 @@ SslBox_t::SslBox_t (bool is_server, const string &privkeyfile, const string &cer
 	 * a new one every time we come here.
 	 */
 
-	Context = new SslContext_t (bIsServer, privkeyfile, certchainfile, use_tls);
+       Context = new SslContext_t (bIsServer, privkeyfile, certchainfile, use_tls, cipherlist);
 	assert (Context);
 
 	pbioRead = BIO_new (BIO_s_mem());

--- a/ext/ssl.h
+++ b/ext/ssl.h
@@ -33,7 +33,7 @@ class SslContext_t
 class SslContext_t
 {
 	public:
-		SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool use_tls);
+               SslContext_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool use_tls, const string &cipherlist);
 		virtual ~SslContext_t();
 
 	private:
@@ -57,7 +57,7 @@ class SslBox_t
 class SslBox_t
 {
 	public:
-		SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool use_tls, const unsigned long binding);
+               SslBox_t (bool is_server, const string &privkeyfile, const string &certchainfile, bool verify_peer, bool use_tls, const string &cipherlist, const unsigned long binding);
 		virtual ~SslBox_t();
 
 		int PutPlaintext (const char*, int);

--- a/java/src/com/rubyeventmachine/SslBox.java
+++ b/java/src/com/rubyeventmachine/SslBox.java
@@ -49,6 +49,7 @@ public class SslBox {
 
 			sslContext.init(keyManagers, new TrustManager[] { tm }, null);
 			sslEngine = sslContext.createSSLEngine(host, port);
+                       sslEngine.setEnabledCipherSuites(sslEngine.getSupportedCipherSuites());
 			sslEngine.setUseClientMode(!isServer);
 			sslEngine.setNeedClientAuth(verifyPeer);
 			

--- a/lib/em/connection.rb
+++ b/lib/em/connection.rb
@@ -382,6 +382,8 @@ module EventMachine
     #
     # @option args [Boolean] :use_tls (false)       indicates whether TLS or SSL must be offered to the peer. If true TLS is used, SSL otherwise.
     #
+    # @option args [String] :cipher_list ("ALL:!ADH:!LOW:!EXP:!DES-CBC3-SHA:@STRENGTH") indicates the available SSL cipher values.
+    #
     # @example Using TLS with EventMachine
     #
     #  require 'rubygems'
@@ -406,7 +408,7 @@ module EventMachine
     #
     # @see #ssl_verify_peer
     def start_tls args={}
-      priv_key, cert_chain, verify_peer, use_tls = args.values_at(:private_key_file, :cert_chain_file, :verify_peer, :use_tls)
+      priv_key, cert_chain, verify_peer, use_tls, cipher_list = args.values_at(:private_key_file, :cert_chain_file, :verify_peer, :use_tls, :cipher_list)
 
       [priv_key, cert_chain].each do |file|
         next if file.nil? or file.empty?
@@ -414,7 +416,7 @@ module EventMachine
         "Could not find #{file} for start_tls" unless File.exists? file
       end
 
-      EventMachine::set_tls_parms(@signature, priv_key || '', cert_chain || '', verify_peer, (use_tls ? true : false))
+      EventMachine::set_tls_parms(@signature, priv_key || '', cert_chain || '', verify_peer, (use_tls ? true : false), cipher_list || '')
       EventMachine::start_tls @signature
     end
 

--- a/lib/jeventmachine.rb
+++ b/lib/jeventmachine.rb
@@ -269,7 +269,7 @@ module EventMachine
     @em.getConnectionCount
   end
 
-  def self.set_tls_parms(sig, privkeyfile, certchainfile, verify_peer)
+  def self.set_tls_parms(sig, privkeyfile, certchainfile, verify_peer, use_tls, cipher_list)
     keystore = KeyStoreBuilder.create privkeyfile, certchainfile unless (privkeyfile.empty? or certchainfile.empty?) 
     @em.setTlsParms(sig, keystore, (!!verify_peer))
   end


### PR DESCRIPTION
- Use Java supported/enabled ciphers, only supporting TLS, as SSLv23/3 are deprecated.
