### PR TITLE
Windows SSL support

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -23,24 +23,16 @@ def append_library(libs, lib)
 end
 
 def manual_ssl_config
-  ssl_libs_heads_args = {
-    :unix => [%w[ssl crypto], %w[openssl/ssl.h openssl/err.h]],
-    :mswin => [%w[ssleay32 eay32], %w[openssl/ssl.h openssl/err.h]],
-  }
-
   dc_flags = ['ssl']
   dc_flags += ["#{ENV['OPENSSL']}/include", ENV['OPENSSL']] if /linux/ =~ RUBY_PLATFORM and ENV['OPENSSL']
 
-  libs, heads = case RUBY_PLATFORM
-  when /mswin/    ; ssl_libs_heads_args[:mswin]
-  else              ssl_libs_heads_args[:unix]
-  end
+  libs, heads = [%w[ssl crypto], %w[openssl/ssl.h openssl/err.h]]
   dir_config(*dc_flags)
   check_libs(libs) and check_heads(heads)
 end
 
 if ENV['CROSS_COMPILING']
-  openssl_version = ENV.fetch("OPENSSL_VERSION", "1.0.0j")
+  openssl_version = ENV.fetch("OPENSSL_VERSION", "1.0.0i")
   openssl_dir = File.expand_path("~/.rake-compiler/builds/openssl-#{openssl_version}/")
   if File.exists?(openssl_dir)
     FileUtils.mkdir_p Dir.pwd+"/openssl/"

--- a/ext/ssl.cpp
+++ b/ext/ssl.cpp
@@ -458,7 +458,7 @@ extern "C" int ssl_verify_wrapper(int preverify_ok, X509_STORE_CTX *ctx)
 
 	cert = X509_STORE_CTX_get_current_cert(ctx);
 	ssl = (SSL*) X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
-	binding = (unsigned long) SSL_get_ex_data(ssl, 0);
+	binding = (intptr_t) SSL_get_ex_data(ssl, 0);
 
 	out = BIO_new(BIO_s_mem());
 	PEM_write_bio_X509(out, cert);

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -23,7 +23,9 @@ if RUBY_PLATFORM =~ /java/
   end
 else
   def setup_cross_compilation(ext)
-    unless RUBY_PLATFORM =~ /mswin|mingw/
+    if RUBY_PLATFORM =~ /mswin|mingw/
+      ext.config_options = "--with-opt-dir=c:/openssl"
+    else
       ext.cross_compile = true
       ext.cross_platform = ['x86-mingw32', 'x86-mswin32-60']
     end


### PR DESCRIPTION
Since https://github.com/sensu/sensu-em/commit/5baa3d1b3dba06d131709355bfe74e7019e5b7ff, the Windows sensu-client will log the following error if ``ssl`` is set to ``true`` in the rabbitmq configuration:

```
C:/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-em-2.4.0/lib/em/connection.rb:419:in `set_tls_parms': wrong number of arguments (6 for 4) (ArgumentError)
```

This is reported at https://groups.google.com/forum/#!topic/sensu-users/EICgMH9V4Qk and has been reported on IRC.

Out of the box, sensu-em will not build on Windows x64 because the OpenSSL lib/include paths are not found and because the wrapper C++ code contains a cast that results in an error when run through MinGW g++.

Using the latest OpenSSL package from Luis Lavena (http://packages.openknapsack.org/openssl/openssl-1.0.0n-x64-windows.tar.lzma) I can build the sensu-em gem with native OpenSSL support. However, this requires a native code change to resolve a compile error because ``unsigned long`` is not a safe type to use for a 64-bit pointer. I was also able to simplify ``extconf.rb`` slightly because the openknapsack package uses the same library names as its Linux counterparts.

This does add a hardcoded path - originally I had made this configurable by adding a Gem called ``pkg-config`` and modifying the ``openssl.pc`` file in the openknapsack package. All told, it ended up requiring a lot of config to avoid a single hardcoded path - I'd look for feedback on what makes more sense there.

I have tested building and installing the ``sensu-em`` gem on Windows 8.1, Server 2008, and 2012 (all 64-bit). I have also built and installed the gem in debian jessie and CentOS 6.

Environment setup instructions are available at https://gist.github.com/ayan4m1/591c83edb9c38e219acf