### PR TITLE
Iterate through copy of UnboundConnections for safety

### DIFF
--- a/java/src/com/rubyeventmachine/EmReactor.java
+++ b/java/src/com/rubyeventmachine/EmReactor.java
@@ -122,7 +122,8 @@ public class EmReactor {
 	}
 
 	void removeUnboundConnections() {
-		for (long b : UnboundConnections) {
+		ArrayList<Long> unboundConnections = (ArrayList<Long>) UnboundConnections.clone();
+		for (long b : unboundConnections) {
 			EventableChannel<?> ec = Connections.remove(b);
 			if (ec != null) {
 				callback.trigger(b, EventCode.EM_CONNECTION_UNBOUND, null, (long) 0);


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

We've been running into `Java::JavaUtil::ConcurrentModificationException` with the new multi-amqp connection changes to sensu-transport. This is happening because the `UnboundConnections` ArrayList is being mutated by a callback while we are iterating through each unbound connection. This change makes a clone of `UnboundConnections` and iterates through the clone instead.