### PR TITLE
send_data return zero when sending to a closed/null connection

### DIFF
--- a/lib/jeventmachine.rb
+++ b/lib/jeventmachine.rb
@@ -118,6 +118,8 @@ module EventMachine
   end
   def self.send_data sig, data, length
     @em.sendData sig, data.to_java_bytes
+  rescue java.lang.NullPointerException
+    0
   end
   def self.send_datagram sig, data, length, address, port
     @em.sendDatagram sig, data.to_java_bytes, length, address, port


### PR DESCRIPTION
Applying https://github.com/eventmachine/eventmachine/pull/804 to our fork.